### PR TITLE
Minor improvements

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -2,19 +2,25 @@
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
         "lineComment": "#",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [  ]
     },
     // symbols used as brackets
     "brackets": [
-        ["(", ")"]
+        ["(", ")"],
+        ["{", "}"],
+        ["[", "]"],
     ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
         ["(", ")"],
+        ["{", "}"],
+        ["[", "]"],
+        ["[[", "]]"]
     ],
     // symbols that can be used to surround a selection
     "surroundingPairs": [
         ["(", ")"],
+        ["{", "}"],
+        ["[", "]"],
+        ["[[", "]]"]
     ]
 }

--- a/syntaxes/rsc.tmLanguage.json
+++ b/syntaxes/rsc.tmLanguage.json
@@ -25,6 +25,9 @@
 		},
 		{
 			"include": "#ctrl-statements"
+		},
+		{
+			"include": "#identifiers"
 		}
 	],
 	"repository": {
@@ -43,11 +46,11 @@
 		"error-chars": {
 			"name": "invalid.illegal",
 			"begin": "\\_\\_",
-			"end": "\\n"
+			"end": "\\b"
 		},
 		"operators":{
 			"name": "keyword.operator",
-			"match": "(\\+=|-=|\\*=|/=|%=|\\^=|&=|\\|=|<<=|>>=|!|\\||\\^|\\+|\\*|\\/)"
+			"match": "(=|\\+|\\-|\\*|\\/|\\^)"
 		},
 		"keywords": {
 			"patterns": [
@@ -63,7 +66,7 @@
 		},
 		"numbers": {
 			"name": "constant.numeric",
-			"match": "[0-9]"
+			"match": "\\b([0-9])+\\b"
 		},
 		"constants": {
 			"patterns": [
@@ -81,6 +84,12 @@
 			"patterns": [{
 				"name" : "keyword.control.rsc",
 				"match": "\\b(if|endif|while|endwhile)\\b"
+			}]
+		},
+		"identifiers": {
+			"patterns": [{
+				"name": "variable.name",
+				"match": "\\b([a-zA-Z_])([a-zA-Z0-9_])*\\b"
 			}]
 		}
 	},


### PR DESCRIPTION
The first commit adds missing brackets and pairs

The second commit has a bunch of small fixups and adds the "identifier" pattern which matches all valid RaychelScript identifiers